### PR TITLE
fix(update 14-预处理器.md): correct the description of the sample catalog

### DIFF
--- a/docs/aspectsofsmacss/14-预处理器.md
+++ b/docs/aspectsofsmacss/14-预处理器.md
@@ -531,7 +531,7 @@ SMACSS的扩展一般在HTML层进行处理而不是在CSS层，即通过在HTML
 一个文件结构样例
 
 ```
-+-layout/
+ +-layout/
  | +-grid.scss
  | +-alternate.scss
  +-module/


### PR DESCRIPTION
# there is a mistake different from the original

1. \docs\aspectsofsmacss\14-预处理器.md > #预处理器 > ##组织好你的CSS文件 > "一个文件结构样例...", the sample catalog has a wrong indent(just one space) which differs from the the original may lead to readers' misunderstanding.